### PR TITLE
Set server port to 3000 instead of 80, so no root

### DIFF
--- a/demo/server.js
+++ b/demo/server.js
@@ -1,3 +1,3 @@
 var express = require("express");
 
-express().use(express.static(__dirname)).use(express.static(__dirname + '/../source')).listen(80);
+express().use(express.static(__dirname)).use(express.static(__dirname + '/../source')).listen(3000);


### PR DESCRIPTION
Running low port numbers typically requires root on *nix systems,
which is something we should avoid for demos.
