### PR TITLE
No Reflow: add height option that avoids the usage of offsetHeight

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -46,7 +46,8 @@
     <span>Move your mouse: </span><span id="sparkline-3" class="sparkline"></span><br>
     <span>This is a sparkline with only one value: </span><span id="sparkline-4" class="sparkline"></span><br>
     <span>This is a sparkline with no values: </span><span id="sparkline-5" class="sparkline"></span><br>
-    <span>Look at this one, it has tooltip on hover: </span><span id="sparkline-6" class="sparkline"></span>
+    <span>Look at this one, it has tooltip on hover: </span><span id="sparkline-6" class="sparkline"></span><br>
+    <span>And this one, with a custom height: </span><span id="sparkline-7" class="sparkline"></span>
   </div>
   <br>
   <br>
@@ -154,6 +155,28 @@
     tooltip: function(value, index, collection){
         return'1/'+(index+1)+' = '+value.toFixed(4);
     }
+  });
+
+  var arr = [];
+  for(var i=0; i<50; i++){
+    arr.push(1/(i+1));
+  }
+
+  sparkline.draw(arr);
+
+})();
+
+(function customHeight(){
+
+  var elm = document.getElementById("sparkline-7");
+
+  var sparkline = new Sparkline(elm, {
+    lineColor: "#666",
+    maxColor: "green",
+    minColor: "red",
+    dotRadius: 3,
+    width: 50,
+    height: 30
   });
 
   var arr = [];

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ Draws the values as a sparkline on the given element, with the specified options
 An object containing the default options for drawing a sparkline. This is shared by all sparkline instances. Change the values of this object before creating sparkline instances. The options (with default values in parenthesis) available are:
 
  * `width` (`100`): A number giving the width of the sparkline box in pixels.
+ * `height` (`null`): A number giving the height of the sparkline box in pixels. By default, uses the height of the Canvas element.
  * `lineColor` (`"black"`): A string giving the color of the sparkline. Any valid CSS color, including RGB, HEX and HSV.
  * `lineWidth` (`1`): A number giving the stroke of the line in pixels.
  * `startColor` (`"transparent"`): A string giving the color of the dot marking the first value. Any valid CSS color.
@@ -79,7 +80,7 @@ An object containing the default options for drawing a sparkline. This is shared
  * `minColor` (`"transparent"`): A string giving the color of the dot marking the lowest value. Any valid CSS color.
  * `minValue` (`null`): A number giving the minimum y-axis value. By default, the lowest data value is used.
  * `maxValue` (`null`): A number giving the maximum y-axis value. By default, the highest data value is used.
- * `dotRadius` (`2.5`): A number giving the size of the dots used to mark important values. 
+ * `dotRadius` (`2.5`): A number giving the size of the dots used to mark important values.
  * `tooltip` (`null`): A function that takes three arguments (`value`, `index`, `array`) and returns a tooltip string to show when the user hovers over the sparkline. By default there is no tooltip.
 
 ### Instance methods

--- a/source/sparkline.js
+++ b/source/sparkline.js
@@ -41,6 +41,7 @@
 
     Sparkline.options = {
         width: 100,
+        height: null,
         lineColor: "black",
         lineWidth: 1,
         startColor: "transparent",
@@ -93,9 +94,11 @@
         this.points = points;
 
         this.canvas.width = this.options.width * this.ratio;
-        this.canvas.height = this.element.offsetHeight * this.ratio;
         this.canvas.style.width = this.options.width + 'px';
-        this.canvas.style.height = this.element.offsetHeight + 'px';
+
+        var pxHeight = this.options.height || this.element.offsetHeight;
+        this.canvas.height = pxHeight * this.ratio;
+        this.canvas.style.height = pxHeight + 'px';
 
         var offsetX = this.options.dotRadius*this.ratio;
         var offsetY = this.options.dotRadius*this.ratio;


### PR DESCRIPTION
Accessing `.offsetHeight` [can trigger a reflow](http://mir.aculo.us/2010/08/17/when-does-javascript-trigger-reflows-and-rendering/)
This change allows the user to specify a width in the constructor
that avoids that accessor.